### PR TITLE
Update Device.java

### DIFF
--- a/sdk/src/com/sharethis/loopy/sdk/Device.java
+++ b/sdk/src/com/sharethis/loopy/sdk/Device.java
@@ -87,7 +87,7 @@ public class Device {
     boolean isOnWifi(Context context) {
         ConnectivityManager connManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo mWifi = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-        return mWifi.isConnected();
+        return (mWifi != null) ? mWifi.isConnected() : false;
     }
 
     String getCarrier(Context context) {


### PR DESCRIPTION
Proposing this change so Device.java works elegantly with virtual Android in general(Android vms are known without wifi hardware and chances are some Android vm software stack is not sufficiently mocking wifi connection module), instead of throwing Java NPEs.

Let me know if you have any other fix in mind that could help solve the problem.
